### PR TITLE
Remove wrong hard-coded path in tutorial notebook 2

### DIFF
--- a/notebooks/02_JAX-Fluids 2D_Bow_Shock_demo.ipynb
+++ b/notebooks/02_JAX-Fluids 2D_Bow_Shock_demo.ipynb
@@ -87,7 +87,6 @@
    "outputs": [],
    "source": [
     "path = sim_manager.output_writer.save_path_domain\n",
-    "path = \"results/bowshock-1/domain\"\n",
     "quantities = [\"density\", \"schlieren\", \"mach_number\", \"levelset\", \"mask_real\"]\n",
     "cell_centers, cell_sizes, times, data_dict = load_data(path, quantities)"
    ]


### PR DESCRIPTION
Hi,

first of all, thanks a lot for the open-source release of such a nice framework :). I have started tinkering around with it and it is beautiful to see, how JAX can be used for sophisticated CFD simulations.

In your example notebooks, I found that there is a wrong hard-coded path. I had to remove it, in order to get it running. Hope this helps others get started.